### PR TITLE
feat: Add “Sync Themes” configuration

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -29,6 +29,12 @@ module.exports = {
             default: 15 * 60, // 15 minutes
             minimum: 1,
         },
+        syncThemes: {
+            title: "Sync Themes",
+            description: "Enable or disable theme syncing across devices.",
+            type: "boolean",
+            default: true,
+        },
     },
 };
 

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -9,6 +9,7 @@ async function getLocalSettings() {
     const { user } = await inkdrop.ipm.getInstalled();
     const enabledThemes = await inkdrop.themes.getEnabledThemeNames();
     const acrylicEnabled = inkdrop.config.get("core.mainWindow.acrylicEnabled");
+    const syncThemes = inkdrop.config.get("settings-sync.syncThemes");
 
     const installedPackages = user
         .filter((x) => !packageIsSelf(x))
@@ -19,13 +20,14 @@ async function getLocalSettings() {
 
     return {
         packages: installedPackages,
-        themes: enabledThemes,
+        themes: syncThemes ? enabledThemes : [],
         acrylicEnabled,
     };
 }
 
 async function setLocalSettings(changed) {
     const current = await getLocalSettings();
+    const syncThemes = inkdrop.config.get("settings-sync.syncThemes");
 
     const { packages: currentPackages, themes: currentThemes } = current;
     const {
@@ -65,14 +67,18 @@ async function setLocalSettings(changed) {
         )
     );
 
-    // Enable changed themes
-    addedThemes.forEach((theme) => inkdrop.packages.enablePackage(theme));
+    if (syncThemes) {
+        const { added: addedThemes } = themeDiff(currentThemes, changedThemes);
 
-    // Set themes
-    inkdrop.config.settings.core.themes = changedThemes;
+        // Enable changed themes
+        addedThemes.forEach((theme) => inkdrop.packages.enablePackage(theme));
 
-    // Apply updated themes to take effect in the GUI
-    await inkdrop.themes.activateThemes();
+        // Set themes
+        inkdrop.config.settings.core.themes = changedThemes;
+
+        // Apply updated themes to take effect in the GUI
+        await inkdrop.themes.activateThemes();
+    }
 }
 
 function safeActivate({ name, isTheme }) {

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -20,7 +20,7 @@ async function getLocalSettings() {
 
     return {
         packages: installedPackages,
-        themes: syncThemes ? enabledThemes : [],
+        themes: enabledThemes,
         acrylicEnabled,
     };
 }
@@ -43,7 +43,6 @@ async function setLocalSettings(changed) {
         currentPackages,
         changedPackages
     );
-    const { added: addedThemes } = themeDiff(currentThemes, changedThemes);
 
     // Set application settings
     inkdrop.config.set("core.mainWindow.acrylicEnabled", changedAcrylicEnabled);


### PR DESCRIPTION
This modified version accepts the "Sync Themes" configuration that turns theme syncing on/off.

Motivation:
I use this plugin on multiple Mac computers. When I use one of these Macs at night, I want to use the Dark mode to make it eye-friendly. However, if I change the Theme settings, this plugin syncs and deploys on all the Macs I use. It is not intended. I want to use the Dark settings on one Mac while the other settings, including installed packages, are always synced.

This PR adds an option "Sync Themes" in the plugin's configuration (`true`/`false`). The theme names' are sent to the Gist only when this configuration is `true`; otherwise, `[]` is sent as the `"themes"` key, and the plugin does not set the theme.